### PR TITLE
fix: .cmxs build racing native stubs archive

### DIFF
--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -369,7 +369,7 @@ let build_shared (lib : Library.t) ~native_archives ~sctx ~dir ~flags =
     ; Hidden_deps
         (let ext_lib = ocaml.lib_config.ext_lib in
          List.rev_concat
-           [ Library.foreign_lib_files lib ~dir ~ext_lib ~for_mode:(Only Byte)
+           [ Library.foreign_lib_files lib ~dir ~ext_lib ~for_mode:(Only Native)
            ; Library.foreign_lib_files lib ~dir ~ext_lib ~for_mode:All
            ; native_archives
            ]

--- a/test/blackbox-tests/test-cases/foreign-stubs/cmxs-mode-dependent-stubs-dep.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/cmxs-mode-dependent-stubs-dep.t
@@ -1,7 +1,9 @@
-Reproduction for https://github.com/ocaml/dune/issues/12964
+Regression test for https://github.com/ocaml/dune/issues/12964
 
-A library with mode-dependent foreign stubs where the .cmxs build does not
-depend on the native stubs archive.
+The .cmxa for a library with mode-dependent foreign stubs links against
+-l<lib>_stubs_native (via -cclib). The .cmxs build, which links the .cmxa
+shared, must therefore depend on libfoo_stubs_native.a — otherwise the link
+can race with the native stubs archive build.
 
   $ cat > dune-project << EOF
   > (lang dune 3.5)
@@ -28,13 +30,8 @@ depend on the native stubs archive.
   $ cat > hash.c
   $ cat > stub.c
 
-Check that the .cmxs rule depends on the native stubs archive.
+The .cmxs rule depends on the native stubs archive, not the byte one.
 
   $ dune rules --format=json foo.cmxs | \
   >   jq -r 'include "dune"; .[] | ruleDepFilePaths | select(test("stubs"))'
-  _build/default/libfoo_stubs_byte.a
-
-This is wrong: the .cmxs links against -lfoo_stubs_native (embedded in the
-.cmxa), so it should depend on libfoo_stubs_native.a, not libfoo_stubs_byte.a.
-This causes a race condition where the .cmxs link can run before the native
-stubs archive is built.
+  _build/default/libfoo_stubs_native.a


### PR DESCRIPTION
## Summary

For libraries with mode-dependent foreign stubs, the `.cmxa` links against `-l<lib>_stubs_native` via `-cclib`. The `.cmxs` link (`ocamlopt -shared`) follows that `-cclib` and statically resolves `libfoo_stubs_native.a`, so the rule must depend on the native stubs archive.

`build_shared` was instead declaring a dep on the **byte** stubs archive (via `Library.foreign_lib_files ~for_mode:(Only Byte)`), which is never referenced anywhere in the cmxs link chain. The native stubs archive was undeclared, so under parallel builds the cmxs link could race the native stubs archive rule and fail with:

```
ld: error: unable to find library -l<lib>_stubs_native
```

This matches the symptom from the FreeBSD/Linux CI flakes reported in #12964.

The fix switches the dep to `Only Native`. For non-mode-dependent stubs both branches return nothing from `foreign_lib_files`, so behavior is unchanged there. For mode-dependent stubs, the cmxs now correctly depends on `libfoo_stubs_native.a`.

Fixes #12964.

## Test plan

- [x] Updated `test/blackbox-tests/test-cases/foreign-stubs/cmxs-mode-dependent-stubs-dep.t` (originally a known-broken reproduction) to assert the correct dep on `libfoo_stubs_native.a`.
- [x] `dune build @check` clean.
- [x] All `test/blackbox-tests/test-cases/foreign-stubs/` tests pass.